### PR TITLE
WIP: Use directives to make profile cards

### DIFF
--- a/client/app/projects/project/project.html
+++ b/client/app/projects/project/project.html
@@ -1,11 +1,13 @@
-<div class="project">
-  <div class="main-wrapper">
-    <title-directive data="project"></title-directive>
-    <p>{{ ::project.description }}</p>
-    <p>Created: {{ ::project.createdAt | date:'MMMM dd, yyyy' }}</p>
-    <h4>Tags</h4>
-    <ul>
-      <li ng-repeat="tag in project.tags track by $index"><a ng-href="">{{ ::tag }}</a></li>
-    </ul>
+<div class="main-wrapper project">
+  <title-directive data="project"></title-directive>
+  <div style="clear:both"></div>
+  <div class="sidebar-col" style="float:left;">
+    <profile-card data="project"></profile-card>
+  </div>
+  <div class="main-content-col">
+    <div class="content-card">
+      <p>{{::project.description}}</p>
+      <img class="project-image" ng-if="project.image" ng-src="{{::project.image}}">
+    </div>
   </div>
 </div>

--- a/client/app/tools/Tool/Tool.html
+++ b/client/app/tools/Tool/Tool.html
@@ -1,8 +1,6 @@
 <div class="main-wrapper cm-tool">
-  	<title-directive data="tool"></title-directive>
-	
+	<title-directive data="tool"></title-directive>
 	<div style="clear:both;"></div>
-
 	<div class="sidebar-col" style="float:left;">
 		<profile-card data="tool"></profile-card>
 	</div>
@@ -12,6 +10,4 @@
 			<img class="tool-image" ng-if="tool.image" ng-src="{{::tool.image}}">
 		</div>
 	</div>
-
 </div>
-


### PR DESCRIPTION
Don't merge yet - creating a PR to start a conversation about how we can
model & use our DB to generate the profile cards.  I'd like to make our
DB uniform in terms of column names so we can better reference them.
For example:  our DB columns for project & tool are different enough
where I can't execute the specs our UX team provided.

I believe we have 2 options:
1. edit our DB so the columns match the UX specs
2. if the DB changes are too costly we can generate the profile cards
   individually but it won't match the UX specs
