### PR TITLE
Consolidated build dependencies into npm scripts + doc updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - '0.10'
   - '0.11'
 before_script:
-  - npm install -g bower grunt-cli
-  - bower install
-  - grunt test
+  - npm install
+  - npm test
 services: mongodb

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
     3. `npm install -g npm`
   - for Mac or Linux via [NVM](https://github.com/creationix/nvm)
     1. `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash`
-    2. `nvm install 4`
-    3. `nvm alias default 4`
+    2. `nvm install 0.10`
+    3. `nvm alias default 0.10`
     4. `echo "export NVM_DIR="$HOME/.nvm" >> $HOME/.bashrc && echo [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" >> $HOME/.bashrc` (optional)
 - Ruby/Sass
   - Linux (Ubuntu):

--- a/README.md
+++ b/README.md
@@ -1,11 +1,36 @@
 # CivicMakers - http://civicmakers.com
 
-## CivicMakers aims to accelerate the capacity for communities, organizations and institutions to rapidly deploy collaborative solutions by growing a network of people, resources and recipes for public good projects. This is a prototype of a knowledge-sharing platform to the civic innovation community. 
+## CivicMakers aims to accelerate the capacity for communities, organizations and institutions to rapidly deploy collaborative solutions by growing a network of people, resources and recipes for public good projects. This is a prototype of a knowledge-sharing platform to the civic innovation community.
 
 
 #### Front-end client
 
+##### dependencies
+
+- XCode (necessary for Mac)
+  - `xcode-select --install`
+- Node/npm
+  - for Mac via Homebrew:
+    1. `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+    2. `brew install node`
+    3. `npm install -g npm`
+  - for Mac or Linux via [NVM](https://github.com/creationix/nvm)
+    1. `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash`
+    2. `nvm install 4`
+    3. `nvm alias default 4`
+    4. `echo "export NVM_DIR="$HOME/.nvm" >> $HOME/.bashrc && echo [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" >> $HOME/.bashrc` (optional)
+- Ruby/Sass
+  - Linux (Ubuntu):
+    1. `sudo apt-get install ruby`
+    2. `git clone https://github.com/rubygems/rubygems.git && cd rubygems && sudo ruby setup.rb`
+    3. `sudo gem install sass`
+  - Mac:
+    1. `git clone https://github.com/rubygems/rubygems.git && cd rubygems && sudo ruby setup.rb`
+    2. `sudo gem install sass`
+
+
 ##### How to run client locally:
+- Install the necessary dependents appropriate to your system, as described above
 - Open your command line and navigate to the folder where you want to save the project.
 - Clone the project repo by entering the following in your command line:
     ```
@@ -15,35 +40,11 @@
     ```
     cd client
     ```
-- Install XCode (if you don't already have it):
-    ```
-    xcode-select --install
-    ```
-- Install HomeBrew (if you don't already have it):
-    ```
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    ```
-- Install Node:
-    ```
-    brew install node
-    ```
-- Update Node Package Manager:
-    ```
-    npm install -g npm
-    ```
-- Install Grunt:
-    ```
-    npm install -g grunt-cli
-    ```
-- Install Bower
-    ```
-    npm install -g bower
-    ```
 - Install the project's tools and dependencies. (This may take a while):
     ```
-    npm install && bower install
+    npm install
     ```
 - Now start the local server!
     ```
-    grunt serve
+    npm run develop
     ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "angular-material": "^0.9.6",
+    "bower": "^1.7.7",
     "connect-livereload": "^0.5.3",
     "firebase-tools": "^2.2.0",
     "grunt": "~0.4.4",
@@ -26,6 +27,7 @@
     "grunt-asset-injector": "^0.1.0",
     "grunt-autoprefixer": "~3.0.3",
     "grunt-build-control": "DaftMonk/grunt-build-control",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "~0.5.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-concat": "^0.4.0",
@@ -83,7 +85,9 @@
     "test": "grunt test",
     "update-webdriver": "node node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update",
     "pre-deploy": "npm install ; node node_modules/firebase-tools/bin/firebase login ; grunt build",
-    "deploy": "node node_modules/firebase-tools/bin/firebase deploy"
+    "deploy": "node node_modules/firebase-tools/bin/firebase deploy",
+    "postinstall": "bower install",
+    "develop": "grunt serve --force"
   },
   "private": "true"
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "scripts": {
     "start": "node server/app.js",
-    "test": "grunt test",
+    "test": "grunt test --force",
     "update-webdriver": "node node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update",
     "pre-deploy": "npm install ; node node_modules/firebase-tools/bin/firebase login ; grunt build",
     "deploy": "node node_modules/firebase-tools/bin/firebase deploy",

--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
   },
   "scripts": {
     "start": "node server/app.js",
-    "test": "grunt test --force",
+    "test": "grunt test",
     "update-webdriver": "node node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update",
     "pre-deploy": "npm install ; node node_modules/firebase-tools/bin/firebase login ; grunt build",
     "deploy": "node node_modules/firebase-tools/bin/firebase deploy",
     "postinstall": "bower install",
-    "develop": "grunt serve --force"
+    "develop": "grunt serve"
   },
   "private": "true"
 }


### PR DESCRIPTION
The original installation method pollutes the users npm global install, and doesn't provide consistent versioning for grunt and bower. I've moved both `bower` and `grunt-cli` to dev dependencies and added `postinstall` script to install bower deps, and `develop` to run develop server.

This way, if you have all the dependencies already, you only need to enter `npm install` and `npm run develop`, and it will install/serve the app.

Also updated README to include dependency information and installation instructions that work for Linux as well as Mac. The original instructions also didn't include instructions on installing sass, which won't necessarily be installed on new devs systems.
