### PR TITLE
Url powered form population on tools and projects

### DIFF
--- a/client/app/projects/AddProject/AddProject.controller.js
+++ b/client/app/projects/AddProject/AddProject.controller.js
@@ -2,15 +2,28 @@
 'use strict';
 
 (function() {
-  function AddProjectCtrl($scope, ProjectApi, $location, ToolApi, AuthenticationService, UserApi, BIEventService) {
+  function AddProjectCtrl($scope, ProjectApi, $location, ToolApi, AuthenticationService, UserApi, BIEventService, $routeParams) {
     var self = this;
     this.projectFormData = {
         // TODO: prevent duplicates
-        tools: []
+        tools: [],
         // authorIp:
         // cfApiProjId:
-        // cfApiOrgId
+        // cfApiOrgId,
+        // pull data from URL parameters
+        description: $routeParams.description || '',
+        image: $routeParams.screenshot || '',
+        link: $routeParams.link || '',
+        name: $routeParams.name || '',
+        tags: [$routeParams.tags] || []
     };
+    // Format tags from URL
+    if (this.projectFormData.tags[0] && this.projectFormData.tags[0].indexOf(',') > -1) {
+      this.projectFormData.tags = this.projectFormData.tags[0].split(',');
+    }
+    // Fill tagsEntry
+    this.tagsEntry = this.projectFormData.tags.join(', ');
+
     // TODO: prevent duplicates
     this.selectedTools = [];
     this.selectedToolsNames = [];
@@ -25,7 +38,7 @@
       this.projectFormData.tools.push(selectedTool.$id);
       this.searchInput = '';
     };
-    
+
     this.searchToolsArrayFilter = function (toolToCheck) {
         var inputLength = self.searchInput.length;
         if (inputLength <= 0) {

--- a/client/app/tools/AddTool/AddTool.controller.js
+++ b/client/app/tools/AddTool/AddTool.controller.js
@@ -4,12 +4,25 @@
 (function() {
   function AddToolCtrl($scope, $routeParams, ToolApi, $location, AuthenticationService, UserApi, BIEventService) {
     var self = this;
+
     this.toolFormData = {
         // authorIp:
         // cfApiProjId:
         // cfApiOrgId
+        avatar: $routeParams.avatar || '',
+        description: $routeParams.description || '',
+        license: $routeParams.license || '',
+        link: $routeParams.link || '',
+        name: $routeParams.name || '',
+        pricing: $routeParams.pricing || '',
+        tags: [$routeParams.tags] || [],
+        twitter: $routeParams.twitter || '',
+        video: $routeParams.screenshot || ''
     };
-
+    if (this.toolFormData.tags[0] && this.toolFormData.tags[0].indexOf(',') > -1) {
+      this.toolFormData.tags = this.toolFormData.tags[0].split(',');
+    }
+    this.tagsEntry = this.toolFormData.tags.join(', ');
     this.tagsEntryChanged = function () {
         this.toolFormData.tags = this.tagsEntry.split(', ');
     };


### PR DESCRIPTION
Example project url:
`http://localhost:9000/add/project?name=Test&description=cool%20description&screenshot=screenshot-url&link=website-url&tags=this,that,foo,bar`

Example tool url:
`http://localhost:9000/add/tool?name=Test&description=cool%20description&avatar=avatar-link&link=website-link&license=Open&pricing=Free&twitter=@example&screenshot=screenshot-url&tags=this,that,foo,bar`

See #193

The only major change I made to the variable nomenclature is the replacement of `video` and `image` with `screenshot`, in tools and projects respectively. This shouldn't effect how the form works internally, I just wanted to standardize the name between the two for future work on a bookmarklet.
