### PR TITLE
set up environment variables

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,8 @@ module.exports = function (grunt) {
     cdnify: 'grunt-google-cdn',
     protractor: 'grunt-protractor-runner',
     injector: 'grunt-asset-injector',
-    buildcontrol: 'grunt-build-control'
+    buildcontrol: 'grunt-build-control',
+    ngconstant: 'grunt-ng-constant'
   });
 
   // Time how long tasks take. Can help when optimizing build times
@@ -532,6 +533,38 @@ module.exports = function (grunt) {
         src: '.tmp/concat/app/styles/app.css',
         dest: 'dist/public/app/styles/app.min.css'
       }
+    },
+    
+    ngconstant: {
+        // Options for all targets
+        options: {
+            space: '  ',
+            wrap: '\'use strict\';\n\n {%= __ngModule %}',
+            name: 'config',
+        },
+        // Environment targets
+        development: {
+            options: {
+                dest: '<%= yeoman.client %>/app/config.js'
+            },
+            constants: {
+                ENV: {
+                    name: 'development',
+                    firebaseUrl: 'civicmakers-dev.firebaseio.com'
+                }
+            }
+        },
+        production: {
+            options: {
+                dest: '<%= yeoman.client %>/app/config.js'
+            },
+            constants: {
+                ENV: {
+                    name: 'production',
+                    firebaseUrl: 'civicmakers.firebaseio.com'
+                }
+            }
+        }
     }
   });
 
@@ -572,6 +605,7 @@ module.exports = function (grunt) {
       'clean:dev',
       'newer:jshint:all',
       'env:all',
+      'ngconstant:development',
       'concurrent:server',
       'injector',
       'wiredep',
@@ -632,6 +666,7 @@ module.exports = function (grunt) {
   grunt.registerTask('build', [
     'newer:jshint:all',
     'clean:dist',
+    'ngconstant:production',
     'sass:dist',
     'autoprefixer',
     'cssmin:dist',

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -6,6 +6,7 @@ angular.module('civicMakersClientApp', [
   'ngSanitize',
   'ngRoute',
   'ngMaterial',
+  'config',
   'firebase',
   'angulartics', 
   'angulartics.google.analytics'

--- a/client/app/config.js
+++ b/client/app/config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+ angular.module('config', [])
+
+.constant('ENV', {name:'development',firebaseUrl:'civicmakers-dev.firebaseio.com'})
+
+;

--- a/client/app/projects/AddProject/AddProject.html
+++ b/client/app/projects/AddProject/AddProject.html
@@ -5,7 +5,7 @@
     Share your project with the civic tech community! What are you working on? What outcomes are you looking for? Tell your peers about your success (or failure) so they can learn from your work!
   </p>
   <p>
-    <strong>NOTE:</strong> To add a tool to your project, you'll need to confirm tool is already in our database by searching in the tool field below. If not, you will need to <a class="link" href="https://civicmakers.firebaseapp.com/add/tool">add it to our database</a> before adding your project. 
+    <strong>NOTE:</strong> To add a tool to your project, you'll need to confirm tool is already in our database by searching in the tool field below. If not, you will need to <a class="link" ng-href="/add/tool">add it to our database</a> before adding your project. 
   </p>
 
   <form class="material-form-group" name="projectForm">

--- a/client/app/services/FirebaseService.js
+++ b/client/app/services/FirebaseService.js
@@ -2,8 +2,8 @@
 'use strict';
 
 (function () {
-  function firebase ($q) {
-    var baseUrl = 'civicmakers.firebaseIO.com';
+  function firebase ($q, ENV) {
+    var baseUrl = ENV.firebaseUrl;
 
     function getRef (){
       var ref = new Firebase(baseUrl);

--- a/client/index.html
+++ b/client/index.html
@@ -158,6 +158,7 @@
   <script src="app/authors/author/author.js"></script>
   <script src="app/authors/authors.controller.js"></script>
   <script src="app/authors/authors.js"></script>
+  <script src="app/config.js"></script>
   <script src="app/directives/cardDirective/cardDirective.directive.js"></script>
   <script src="app/directives/profileCard/profileCard.directive.js"></script>
   <script src="app/directives/questionsAndAnswers/question.directive.js"></script>

--- a/client/views/privacy-policy.html
+++ b/client/views/privacy-policy.html
@@ -3,7 +3,7 @@
 
     <h3>1. Terms</h3>
 
-    <p>By accessing the web site at <a href="http://civicmakers.firebaseapp.com">http://civicmakers.firebaseapp.com</a>, you are agreeing to be bound by these web site Terms and Conditions of Use, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this web site are protected by applicable copyright and trademark law.</p>
+    <p>By accessing the web site at <a ng-href="/">http://civicmakers.firebaseapp.com</a>, you are agreeing to be bound by these web site Terms and Conditions of Use, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this web site are protected by applicable copyright and trademark law.</p>
 
     <h3>2. Use License</h3>
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-mocha-test": "~0.10.2",
     "grunt-newer": "^0.7.0",
     "grunt-ng-annotate": "^1.0.0",
+    "grunt-ng-constant": "^2.0.1",
     "grunt-node-inspector": "^0.4.1",
     "grunt-nodemon": "~0.2.0",
     "grunt-open": "~0.2.3",


### PR DESCRIPTION
Sets up the environment variable for Firebase to go to the correct DB (dev/production).
It's done by a grunt task called grunt-ng-constant which defines the env vars in the gruntfile itself and creates a config module that includes an ENV constant according to the used grunt task.

To use when developing just run 'grunt serve'.
To work on production DB locally run 'grunt serve:dist'.
When deploying new code to production through the firebase hosting (npm run pre-deploy, npm run deploy) it uses the 'grunt build' task which updates the configuration to the production env. 
